### PR TITLE
Add builtin `export`

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sarchoi <sarchoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/31 13:26:10 by sarchoi           #+#    #+#             */
-/*   Updated: 2022/04/03 13:40:29 by sarchoi          ###   ########seoul.kr  */
+/*   Updated: 2022/04/03 16:58:30 by sarchoi          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,17 +48,22 @@ typedef struct s_minishell
 t_minishell		g_mini;
 
 /*
-** env
+** init: env
 */
 void	init_env(char **envp);
-int		ft_env();
 
+/*
+** builtin
+*/
+int		ft_env();
 int		ft_unset(char *var_name);
+int		ft_export(char *str);
 
 /*
 ** util: var
 */
 void	add_var(char *name_and_value, int scope);
+t_var	*find_var(char *name);
 char	*find_var_value(char *name);
 void	update_var(char *name, char *new_value);
 void	remove_var(char *name);

--- a/src/builtin/export.c
+++ b/src/builtin/export.c
@@ -1,47 +1,32 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   env.c                                              :+:      :+:    :+:   */
+/*   export.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: sarchoi <sarchoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2022/04/01 17:54:44 by sarchoi           #+#    #+#             */
-/*   Updated: 2022/04/03 16:56:20 by sarchoi          ###   ########seoul.kr  */
+/*   Created: 2022/04/03 14:20:03 by sarchoi           #+#    #+#             */
+/*   Updated: 2022/04/03 16:57:00 by sarchoi          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+#include <string.h>
 
-static void	increase_shlvl()
-{
-	int	prev_value;
-
-	prev_value = ft_atoi(getenv("SHLVL"));
-	update_var("SHLVL", ft_itoa(prev_value + 1));
-}
-
-void	init_env(char **envp)
-{
-	add_var(ft_strdup(*envp), ENV_VAR);
-	envp++;
-	while (*envp)
-	{
-		add_var(ft_strdup(*envp), ENV_VAR);
-		envp++;
-	}
-	increase_shlvl();
-}
-
-int	ft_env()
+int	ft_export(char *str)
 {
 	t_var	*tmp;
 
-	tmp = g_mini.env;
-	while (tmp)
+	if (!str)
+		return (ft_env());
+	if (ft_strchr(str, '='))
 	{
-		if (tmp->scope == ENV_VAR)
-			printf("%s\n", (char *)tmp->var);
-		tmp = tmp->next;
+		add_var(str, ENV_VAR);
+		return (FT_SUCCESS);
 	}
+	tmp = find_var(str);
+	if (!tmp)
+		return (FT_ERROR);
+	tmp->scope = ENV_VAR;
 	return (FT_SUCCESS);
 }

--- a/src/builtin/export.c
+++ b/src/builtin/export.c
@@ -6,12 +6,11 @@
 /*   By: sarchoi <sarchoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/03 14:20:03 by sarchoi           #+#    #+#             */
-/*   Updated: 2022/04/03 16:57:00 by sarchoi          ###   ########seoul.kr  */
+/*   Updated: 2022/04/04 17:30:23 by sarchoi          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-#include <string.h>
 
 int	ft_export(char *str)
 {

--- a/src/util/var_util.c
+++ b/src/util/var_util.c
@@ -6,7 +6,7 @@
 /*   By: sarchoi <sarchoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/03 02:33:43 by sarchoi           #+#    #+#             */
-/*   Updated: 2022/04/03 13:53:50 by sarchoi          ###   ########seoul.kr  */
+/*   Updated: 2022/04/03 16:58:27 by sarchoi          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,20 +39,6 @@ static t_var	*var_new(char *var, int scope)
 	return (new);
 }
 
-static t_var	*var_find(char *name)
-{
-	t_var	*tmp;
-
-	tmp = g_mini.env;
-	while (tmp)
-	{
-		if (ft_strncmp(tmp->var, name, name_len(tmp->var)) == 0)
-			return (tmp);
-		tmp = tmp->next;
-	}
-	return ((t_var *)NULL);
-}
-
 void	add_var(char *name_and_value, int scope)
 {
 	t_var *tmp;
@@ -70,6 +56,20 @@ void	add_var(char *name_and_value, int scope)
 	tmp->next = new;
 }
 
+t_var	*find_var(char *name)
+{
+	t_var	*tmp;
+
+	tmp = g_mini.env;
+	while (tmp)
+	{
+		if (ft_strncmp(tmp->var, name, name_len(tmp->var)) == 0)
+			return (tmp);
+		tmp = tmp->next;
+	}
+	return ((t_var *)NULL);
+}
+
 /*
 ** get var valye by name
 */
@@ -77,7 +77,7 @@ char	*find_var_value(char *name)
 {
 	t_var	*tmp;
 
-	tmp = var_find(name);
+	tmp = find_var(name);
 	if (!tmp)
 		return ((char *)NULL);
 	return (tmp->var + name_len(tmp->var) + 1);
@@ -88,7 +88,7 @@ void	update_var(char *name, char *new_value)
 	t_var	*tmp;
 	char	*new;
 
-	tmp = var_find(name);
+	tmp = find_var(name);
 	if (!tmp)
 		return ;
 	new = ft_strjoin(name, "=");


### PR DESCRIPTION
- issue #7 
- [Bash 레퍼런스](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/html_node/Bourne-Shell-Builtins.html#Bourne-Shell-Builtins)에 따라 인자가 없는 `export`를 실행할 경우, `env`와 동일하게 단순 출력(정렬하지 않음)
