### PR TITLE
Fix memory leak in move_to_cdpath

### DIFF
--- a/libft/ft_split.c
+++ b/libft/ft_split.c
@@ -6,7 +6,7 @@
 /*   By: sarchoi <sarchoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/05 18:45:00 by sarchoi           #+#    #+#             */
-/*   Updated: 2022/04/19 14:34:54 by sarchoi          ###   ########seoul.kr  */
+/*   Updated: 2022/04/27 16:26:06 by sarchoi          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,7 +72,8 @@ char			**ft_split_free(char **tab)
 	i = 0;
 	while (tab[i])
 	{
-		free(tab[i]);
+		if (tab[i])
+			free(tab[i]);
 		i++;
 	}
 	free(tab);

--- a/src/builtin/cd.c
+++ b/src/builtin/cd.c
@@ -6,7 +6,7 @@
 /*   By: sarchoi <sarchoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/07 13:32:11 by sarchoi           #+#    #+#             */
-/*   Updated: 2022/04/27 15:47:46 by sarchoi          ###   ########seoul.kr  */
+/*   Updated: 2022/04/27 16:28:56 by sarchoi          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,10 +57,12 @@ static void	move_to_oldpwd(void)
 static int	move_to_cdpath(char *path)
 {
 	char	**cdpaths;
+	char	**cdpaths_start;
 	char	*dir;
 	char	*tmp;
 
 	cdpaths = ft_split(find_var_value("CDPATH"), ':');
+	cdpaths_start = cdpaths;
 	while (*cdpaths)
 	{
 		tmp = ft_strjoin(*cdpaths, "/");
@@ -70,13 +72,13 @@ static int	move_to_cdpath(char *path)
 		{
 			print_cwd();
 			free(dir);
-			ft_split_free(cdpaths);
+			ft_split_free(cdpaths_start);
 			return (FT_TRUE);
 		}
 		free(dir);
-		ft_split_free(cdpaths);
 		cdpaths++;
 	}
+	ft_split_free(cdpaths_start);
 	return (FT_FALSE);
 }
 


### PR DESCRIPTION
- #108 
- `ft_split_free`의 시작 포인터가 올바르지 않았던 문제