### PR TITLE
Update builtin export without args to do not print 'declare -x'

### DIFF
--- a/src/util/export.c
+++ b/src/util/export.c
@@ -6,7 +6,7 @@
 /*   By: sarchoi <sarchoi@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/27 23:12:28 by sarchoi           #+#    #+#             */
-/*   Updated: 2022/05/04 20:10:21 by sarchoi          ###   ########seoul.kr  */
+/*   Updated: 2022/05/07 15:24:27 by sarchoi          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,7 +69,6 @@ static void	print_array(char **array)
 	i = 0;
 	while (array[i])
 	{
-		ft_putstr_fd("declare -x ", 1);
 		ft_putstr_fd(array[i], 1);
 		ft_putchar_fd('\n', 1);
 		i++;


### PR DESCRIPTION
- #165 

closes #165